### PR TITLE
Download the build harness bootstrap Makefile only when it's not present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,9 @@ USE_VENDORIZED_BUILD_HARNESS ?=
 
 ifndef USE_VENDORIZED_BUILD_HARNESS
 	ifeq ($(TRAVIS_BUILD),1)
-	-include $(shell curl -H 'Accept: application/vnd.github.v4.raw' -L https://api.github.com/repos/open-cluster-management/build-harness-extensions/contents/templates/Makefile.build-harness-bootstrap -o .build-harness-bootstrap; echo .build-harness-bootstrap)
+		ifeq (,$(wildcard ./.build-harness-bootstrap))
+			-include $(shell curl -H 'Accept: application/vnd.github.v4.raw' -L https://api.github.com/repos/open-cluster-management/build-harness-extensions/contents/templates/Makefile.build-harness-bootstrap -o .build-harness-bootstrap; echo .build-harness-bootstrap)
+		endif
 	endif
 else
 -include vbh/.build-harness-vendorized


### PR DESCRIPTION
This will reduce the number of downloads of the file and reduce the
chances of hitting GitHub's rate limit.

This resolves part of open-cluster-management-io/community#57.