### PR TITLE
Backport update to the owners file for the 2.3 release

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,8 +5,6 @@ approvers:
 - gparvin
 - JustinKuli
 - willkutler
-- ycao56
-
 reviewers:
 - ChunxiAlexLuo
 - ckandag
@@ -14,4 +12,3 @@ reviewers:
 - gparvin
 - JustinKuli
 - willkutler
-- ycao56


### PR DESCRIPTION
Cherry pick failed so manually backporting the Owners file update

Signed-off-by: Gus Parvin <gparvin@redhat.com>