### PR TITLE
Default the health endpoint port to 8083

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	pflag.BoolVar(&legacyLeaderElect, "legacy-leader-elect", false,
 		"Use a legacy leader election method for controller manager instead of the lease API.")
-	pflag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	pflag.StringVar(&probeAddr, "health-probe-bind-address", ":8083", "The address the probe endpoint binds to.")
 
 	pflag.Parse()
 

--- a/test/resources/case1_template_sync/case1-config-policy-enforce.yaml
+++ b/test/resources/case1_template_sync/case1-config-policy-enforce.yaml
@@ -4,6 +4,7 @@ metadata:
   name: case1-config-policy
 spec:
   remediationAction: enforce
+  pruneObjectBehavior: "None"
   object-templates:
     - complianceType: musthave
       objectDefinition:

--- a/test/resources/case1_template_sync/case1-config-policy.yaml
+++ b/test/resources/case1_template_sync/case1-config-policy.yaml
@@ -4,6 +4,7 @@ metadata:
   name: case1-config-policy
 spec:
   remediationAction: inform
+  pruneObjectBehavior: "None"
   object-templates:
     - complianceType: musthave
       objectDefinition:

--- a/test/resources/case2_error_test/remedation-action-not-exists-configpolicy.yaml
+++ b/test/resources/case2_error_test/remedation-action-not-exists-configpolicy.yaml
@@ -4,6 +4,7 @@ metadata:
   name: case2-remedation-action-not-exists-configpolicy
 spec:
   remediationAction: inform
+  pruneObjectBehavior: "None"
   object-templates:
     - complianceType: musthave
       objectDefinition:


### PR DESCRIPTION
This makes it not conflict with the spec sync health endpoint by
default.

Related:
https://github.com/open-cluster-management-io/governance-policy-addon-controller/commit/918eeb7739f8db71f386068ac7eb236aac2c3859
https://github.com/stolostron/backlog/issues/24148

Signed-off-by: mprahl <mprahl@users.noreply.github.com>