### PR TITLE
Handle when the template sync encounters a conflict

### DIFF
--- a/controllers/template_sync.go
+++ b/controllers/template_sync.go
@@ -303,6 +303,12 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 
 			_, err = res.Update(ctx, eObject, metav1.UpdateOptions{})
 			if err != nil {
+				// If the policy template retrieved from the cache has since changed, there will be a conflict error
+				// and the reconcile should be retried since this is recoverable.
+				if errors.IsConflict(err) {
+					return reconcile.Result{}, err
+				}
+
 				resultError = err
 				errMsg := fmt.Sprintf("Failed to update policy template %s: %s", tName, err)
 


### PR DESCRIPTION
When there is a conflict, the reconcile should be retried rather than emit a policy violation.

This a cherry-pick from:
https://github.com/open-cluster-management-io/governance-policy-framework-addon/commit/5711c68990c3d57f65422dfb6093c7c0694c8035

This change is necessary in case the consolidated sync controller project is not complete by the next release.